### PR TITLE
feat: per-model tool name rewriting + Gemma 4 output token parsing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -106,6 +106,8 @@ services:
     image: nginx:latest
     ports:
       - "8000:80"
+    volumes:
+      - ./tests/mock-provider.conf:/etc/nginx/conf.d/default.conf:ro
     restart: unless-stopped
 
 volumes:

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -684,6 +684,7 @@ func (s *Server) refreshPricing() {
 				Enabled:          m.Enabled,
 				PricingSource:    m.PricingSource,
 				ToolNameMap:      m.ToolNameMap,
+				Gemma4Output:     m.Gemma4Output,
 			})
 			updated++
 		}
@@ -1167,6 +1168,7 @@ func loadPersistedModels(eng *router.Engine, db store.Store, logger *slog.Logger
 			Enabled:          m.Enabled,
 			PricingSource:    m.PricingSource,
 			ToolNameMap:      m.ToolNameMap,
+			Gemma4Output:     m.Gemma4Output,
 		})
 	}
 	if len(models) > 0 {

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -683,6 +683,7 @@ func (s *Server) refreshPricing() {
 				OutputPer1K:      m.OutputPer1K,
 				Enabled:          m.Enabled,
 				PricingSource:    m.PricingSource,
+				ToolNameMap:      m.ToolNameMap,
 			})
 			updated++
 		}
@@ -795,13 +796,14 @@ func loadCredentialsFile(path string, eng *router.Engine, v *vault.Vault, db sto
 		AutoloadModels bool   `json:"autoload_models"` // fetch all models from provider on startup
 	}
 	type credModel struct {
-		ID               string  `json:"id"`
-		ProviderID       string  `json:"provider_id"`
-		Weight           int     `json:"weight"`
-		MaxContextTokens int     `json:"max_context_tokens"`
-		InputPer1K       float64 `json:"input_per_1k"`
-		OutputPer1K      float64 `json:"output_per_1k"`
-		Enabled          *bool   `json:"enabled"` // nil = true
+		ID               string            `json:"id"`
+		ProviderID       string            `json:"provider_id"`
+		Weight           int               `json:"weight"`
+		MaxContextTokens int               `json:"max_context_tokens"`
+		InputPer1K       float64           `json:"input_per_1k"`
+		OutputPer1K      float64           `json:"output_per_1k"`
+		Enabled          *bool             `json:"enabled"` // nil = true
+		ToolNameMap      map[string]string `json:"tool_name_map,omitempty"`
 	}
 	type credFile struct {
 		Providers []credProvider `json:"providers"`
@@ -899,6 +901,7 @@ func loadCredentialsFile(path string, eng *router.Engine, v *vault.Vault, db sto
 			InputPer1K:       m.InputPer1K,
 			OutputPer1K:      m.OutputPer1K,
 			Enabled:          enabled,
+			ToolNameMap:      m.ToolNameMap,
 		}
 		eng.RegisterModel(model)
 
@@ -908,6 +911,7 @@ func loadCredentialsFile(path string, eng *router.Engine, v *vault.Vault, db sto
 				ID: m.ID, ProviderID: m.ProviderID, Weight: m.Weight,
 				MaxContextTokens: m.MaxContextTokens, InputPer1K: m.InputPer1K,
 				OutputPer1K: m.OutputPer1K, Enabled: enabled,
+				ToolNameMap: m.ToolNameMap,
 			}); err != nil {
 				logger.Warn("failed to persist credentials model", slog.String("model", m.ID), slog.String("error", err.Error()))
 			}
@@ -1162,6 +1166,7 @@ func loadPersistedModels(eng *router.Engine, db store.Store, logger *slog.Logger
 			OutputPer1K:      m.OutputPer1K,
 			Enabled:          m.Enabled,
 			PricingSource:    m.PricingSource,
+			ToolNameMap:      m.ToolNameMap,
 		})
 	}
 	if len(models) > 0 {

--- a/internal/httpapi/gemma4.go
+++ b/internal/httpapi/gemma4.go
@@ -1,0 +1,388 @@
+package httpapi
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// gemma4StringDelim is the special token Gemma 4 uses to wrap string values
+// inside tool call argument lists.
+const gemma4StringDelim = "<|\"|>"
+
+var (
+	// gemma4ThinkRe matches <|channel>thought\n...<channel|> thinking blocks.
+	gemma4ThinkRe = regexp.MustCompile(`(?s)<\|channel>thought\n.*?<channel\|>`)
+	// gemma4ToolCallRe matches <|tool_call>call:name{args}<tool_call|>.
+	// Group 1 = function name, group 2 = raw args string.
+	gemma4ToolCallRe = regexp.MustCompile(`(?s)<\|tool_call>call:(\w+)\{(.*?)\}<tool_call\|>`)
+)
+
+// gemma4ToolCallResult holds a parsed Gemma 4 tool call.
+type gemma4ToolCallResult struct {
+	Name      string
+	Arguments string // JSON object string ready for OpenAI tool_calls
+}
+
+// gemma4ArgsToJSON converts Gemma 4's key:value argument notation to a JSON
+// object string. String values are wrapped with <|"|>...<|"|>; non-string
+// values are bare JSON literals (numbers, booleans, null).
+func gemma4ArgsToJSON(args string) string {
+	result := make(map[string]any)
+	i := 0
+	for i < len(args) {
+		colonIdx := strings.IndexByte(args[i:], ':')
+		if colonIdx < 0 {
+			break
+		}
+		key := strings.TrimSpace(args[i : i+colonIdx])
+		if key == "" {
+			break
+		}
+		i += colonIdx + 1
+
+		if strings.HasPrefix(args[i:], gemma4StringDelim) {
+			// String value: <|"|>value<|"|>
+			i += len(gemma4StringDelim)
+			end := strings.Index(args[i:], gemma4StringDelim)
+			if end < 0 {
+				result[key] = args[i:]
+				break
+			}
+			result[key] = args[i : i+end]
+			i += end + len(gemma4StringDelim)
+		} else {
+			// Non-string literal: up to the next comma or end.
+			end := strings.IndexByte(args[i:], ',')
+			var raw string
+			if end < 0 {
+				raw = strings.TrimSpace(args[i:])
+				i = len(args)
+			} else {
+				raw = strings.TrimSpace(args[i : i+end])
+				i += end + 1
+			}
+			var v any
+			if json.Unmarshal([]byte(raw), &v) == nil {
+				result[key] = v
+			} else {
+				result[key] = raw
+			}
+		}
+		if i < len(args) && args[i] == ',' {
+			i++
+		}
+	}
+	out, _ := json.Marshal(result)
+	return string(out)
+}
+
+// gemma4ParseContent strips Gemma 4 thinking blocks and extracts inline tool
+// calls from content. Returns the cleaned text and any parsed tool calls.
+func gemma4ParseContent(content string) (string, []gemma4ToolCallResult) {
+	content = strings.TrimSpace(gemma4ThinkRe.ReplaceAllString(content, ""))
+
+	matches := gemma4ToolCallRe.FindAllStringSubmatchIndex(content, -1)
+	if len(matches) == 0 {
+		return content, nil
+	}
+
+	var calls []gemma4ToolCallResult
+	var sb strings.Builder
+	prev := 0
+	for _, m := range matches {
+		sb.WriteString(content[prev:m[0]])
+		calls = append(calls, gemma4ToolCallResult{
+			Name:      content[m[2]:m[3]],
+			Arguments: gemma4ArgsToJSON(content[m[4]:m[5]]),
+		})
+		prev = m[1]
+	}
+	sb.WriteString(content[prev:])
+	return strings.TrimSpace(sb.String()), calls
+}
+
+// rewriteGemma4Choices transforms the choices array from a Gemma 4 response
+// into standard OpenAI format. Thinking blocks are stripped from content;
+// inline tool call tokens are converted to tool_calls entries.
+func rewriteGemma4Choices(choices json.RawMessage) json.RawMessage {
+	type toolFunction struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	}
+	type toolCall struct {
+		ID       string       `json:"id"`
+		Type     string       `json:"type"`
+		Function toolFunction `json:"function"`
+	}
+	type message struct {
+		Role      string          `json:"role,omitempty"`
+		Content   json.RawMessage `json:"content"`
+		ToolCalls []toolCall      `json:"tool_calls,omitempty"`
+	}
+	type choice struct {
+		Index        int             `json:"index"`
+		Message      message         `json:"message"`
+		FinishReason *string         `json:"finish_reason"`
+		Logprobs     json.RawMessage `json:"logprobs,omitempty"`
+	}
+
+	var arr []choice
+	if err := json.Unmarshal(choices, &arr); err != nil {
+		return choices
+	}
+
+	changed := false
+	for i, c := range arr {
+		var contentStr string
+		if err := json.Unmarshal(c.Message.Content, &contentStr); err != nil {
+			continue // null or non-string content
+		}
+
+		cleaned, calls := gemma4ParseContent(contentStr)
+		if cleaned == contentStr && len(calls) == 0 {
+			continue
+		}
+		changed = true
+
+		if len(calls) > 0 {
+			tcs := make([]toolCall, len(calls))
+			for j, tc := range calls {
+				tcs[j] = toolCall{
+					ID:   fmt.Sprintf("call_%d_%d", i, j),
+					Type: "function",
+					Function: toolFunction{
+						Name:      tc.Name,
+						Arguments: tc.Arguments,
+					},
+				}
+			}
+			arr[i].Message.ToolCalls = tcs
+			reason := "tool_calls"
+			arr[i].FinishReason = &reason
+		}
+		if cleaned == "" {
+			arr[i].Message.Content = json.RawMessage("null")
+		} else {
+			raw, _ := json.Marshal(cleaned)
+			arr[i].Message.Content = raw
+		}
+	}
+
+	if !changed {
+		return choices
+	}
+	out, err := json.Marshal(arr)
+	if err != nil {
+		return choices
+	}
+	return out
+}
+
+// gemma4ContentAcc accumulates SSE content deltas for one choice index.
+type gemma4ContentAcc struct {
+	role    string
+	content strings.Builder
+}
+
+// newSSEGemma4Transformer wraps a Gemma 4 SSE stream. Because Gemma 4's tool
+// call tokens span many content deltas, it buffers all content per choice and
+// emits properly structured OpenAI SSE chunks once the stream ends.
+func newSSEGemma4Transformer(src io.ReadCloser) io.ReadCloser {
+	pr, pw := io.Pipe()
+	go func() {
+		defer src.Close()
+		defer pw.Close()
+
+		type chunkMeta struct {
+			id      string
+			object  string
+			created int64
+			model   string
+		}
+
+		var meta chunkMeta
+		hasMeta := false
+		accs := make(map[int]*gemma4ContentAcc)
+
+		emit := func(data string) {
+			_, _ = pw.Write([]byte("data: " + data + "\n\n"))
+		}
+
+		scanner := bufio.NewScanner(src)
+		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			if !strings.HasPrefix(line, "data: ") {
+				_, _ = pw.Write([]byte(line + "\n"))
+				continue
+			}
+			data := line[6:]
+			if data == "[DONE]" {
+				gemma4EmitSSE(emit, meta.id, meta.object, meta.created, meta.model, hasMeta, accs)
+				_, _ = pw.Write([]byte("data: [DONE]\n\n"))
+				return
+			}
+
+			var raw struct {
+				ID      string `json:"id"`
+				Object  string `json:"object"`
+				Created int64  `json:"created"`
+				Model   string `json:"model"`
+				Choices []struct {
+					Index int `json:"index"`
+					Delta struct {
+						Role    string `json:"role,omitempty"`
+						Content string `json:"content,omitempty"`
+					} `json:"delta"`
+					FinishReason *string `json:"finish_reason"`
+				} `json:"choices"`
+			}
+			if err := json.Unmarshal([]byte(data), &raw); err != nil {
+				_, _ = pw.Write([]byte(line + "\n\n"))
+				continue
+			}
+			if !hasMeta {
+				meta = chunkMeta{id: raw.ID, object: raw.Object, created: raw.Created, model: raw.Model}
+				hasMeta = true
+			}
+			for _, c := range raw.Choices {
+				a, ok := accs[c.Index]
+				if !ok {
+					a = &gemma4ContentAcc{role: c.Delta.Role}
+					accs[c.Index] = a
+				}
+				if c.Delta.Role != "" && a.role == "" {
+					a.role = c.Delta.Role
+				}
+				a.content.WriteString(c.Delta.Content)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			pw.CloseWithError(err)
+		}
+	}()
+	return pr
+}
+
+// gemma4EmitSSE emits the buffered Gemma 4 content as OpenAI-format SSE chunks.
+func gemma4EmitSSE(emit func(string), id, object string, created int64, model string, hasMeta bool, accs map[int]*gemma4ContentAcc) {
+	type toolFunction struct {
+		Name      string `json:"name,omitempty"`
+		Arguments string `json:"arguments,omitempty"`
+	}
+	type toolCallDelta struct {
+		Index    int          `json:"index"`
+		ID       string       `json:"id,omitempty"`
+		Type     string       `json:"type,omitempty"`
+		Function toolFunction `json:"function"`
+	}
+	type delta struct {
+		Role      string          `json:"role,omitempty"`
+		Content   *string         `json:"content,omitempty"`
+		ToolCalls []toolCallDelta `json:"tool_calls,omitempty"`
+	}
+	type choice struct {
+		Index        int     `json:"index"`
+		Delta        delta   `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	}
+	type chunk struct {
+		ID      string   `json:"id"`
+		Object  string   `json:"object"`
+		Created int64    `json:"created"`
+		Model   string   `json:"model"`
+		Choices []choice `json:"choices"`
+	}
+
+	if !hasMeta || len(accs) == 0 {
+		return
+	}
+	if object == "" {
+		object = "chat.completion.chunk"
+	}
+
+	// Process each choice index in order.
+	for idx := 0; idx < len(accs); idx++ {
+		a, ok := accs[idx]
+		if !ok {
+			continue
+		}
+
+		cleaned, calls := gemma4ParseContent(a.content.String())
+
+		// Emit role delta.
+		role := a.role
+		if role == "" {
+			role = "assistant"
+		}
+		roleChunk := chunk{
+			ID: id, Object: object, Created: created, Model: model,
+			Choices: []choice{{Index: idx, Delta: delta{Role: role}, FinishReason: nil}},
+		}
+		if b, err := json.Marshal(roleChunk); err == nil {
+			emit(string(b))
+		}
+
+		// Emit content delta if any text remains.
+		if cleaned != "" {
+			contentChunk := chunk{
+				ID: id, Object: object, Created: created, Model: model,
+				Choices: []choice{{Index: idx, Delta: delta{Content: &cleaned}, FinishReason: nil}},
+			}
+			if b, err := json.Marshal(contentChunk); err == nil {
+				emit(string(b))
+			}
+		}
+
+		if len(calls) > 0 {
+			// Emit one chunk per tool call with name + arguments.
+			for j, tc := range calls {
+				callID := fmt.Sprintf("call_%d_%d", idx, j)
+				callChunk := chunk{
+					ID: id, Object: object, Created: created, Model: model,
+					Choices: []choice{{
+						Index: idx,
+						Delta: delta{
+							ToolCalls: []toolCallDelta{{
+								Index:    j,
+								ID:       callID,
+								Type:     "function",
+								Function: toolFunction{Name: tc.Name, Arguments: tc.Arguments},
+							}},
+						},
+						FinishReason: nil,
+					}},
+				}
+				if b, err := json.Marshal(callChunk); err == nil {
+					emit(string(b))
+				}
+			}
+			// Final chunk with finish_reason: tool_calls.
+			reason := "tool_calls"
+			finishChunk := chunk{
+				ID: id, Object: object, Created: created, Model: model,
+				Choices: []choice{{Index: idx, Delta: delta{}, FinishReason: &reason}},
+			}
+			if b, err := json.Marshal(finishChunk); err == nil {
+				emit(string(b))
+			}
+		} else {
+			// Final chunk with finish_reason: stop.
+			reason := "stop"
+			finishChunk := chunk{
+				ID: id, Object: object, Created: created, Model: model,
+				Choices: []choice{{Index: idx, Delta: delta{}, FinishReason: &reason}},
+			}
+			if b, err := json.Marshal(finishChunk); err == nil {
+				emit(string(b))
+			}
+		}
+	}
+}

--- a/internal/httpapi/gemma4_test.go
+++ b/internal/httpapi/gemma4_test.go
@@ -1,0 +1,189 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGemma4ArgsToJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want map[string]any
+	}{
+		{
+			name: "single string arg",
+			args: `query:<|"|>quest team OR hermes deploy<|"|>`,
+			want: map[string]any{"query": "quest team OR hermes deploy"},
+		},
+		{
+			name: "multiple args mixed types",
+			args: `name:<|"|>foo<|"|>,count:42,flag:true`,
+			want: map[string]any{"name": "foo", "count": float64(42), "flag": true},
+		},
+		{
+			name: "string with commas inside",
+			args: `query:<|"|>a OR b, c OR d<|"|>`,
+			want: map[string]any{"query": "a OR b, c OR d"},
+		},
+		{
+			name: "empty args",
+			args: ``,
+			want: map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gemma4ArgsToJSON(tt.args)
+			var m map[string]any
+			if err := json.Unmarshal([]byte(got), &m); err != nil {
+				t.Fatalf("gemma4ArgsToJSON returned invalid JSON: %v", err)
+			}
+			for k, want := range tt.want {
+				got, ok := m[k]
+				if !ok {
+					t.Errorf("missing key %q", k)
+					continue
+				}
+				if got != want {
+					t.Errorf("key %q: got %v, want %v", k, got, want)
+				}
+			}
+			if len(m) != len(tt.want) {
+				t.Errorf("got %d keys, want %d", len(m), len(tt.want))
+			}
+		})
+	}
+}
+
+func TestGemma4ParseContent(t *testing.T) {
+	t.Run("strips think block", func(t *testing.T) {
+		input := "<|channel>thought\nI should search for this.\n<channel|>\nHere is my answer."
+		cleaned, calls := gemma4ParseContent(input)
+		if cleaned != "Here is my answer." {
+			t.Errorf("got %q, want %q", cleaned, "Here is my answer.")
+		}
+		if len(calls) != 0 {
+			t.Errorf("expected no tool calls, got %d", len(calls))
+		}
+	})
+
+	t.Run("extracts tool call", func(t *testing.T) {
+		input := `<|tool_call>call:session_search{query:<|"|>quest team OR hermes deploy<|"|>}<tool_call|>`
+		cleaned, calls := gemma4ParseContent(input)
+		if cleaned != "" {
+			t.Errorf("expected empty content, got %q", cleaned)
+		}
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 tool call, got %d", len(calls))
+		}
+		if calls[0].Name != "session_search" {
+			t.Errorf("name: got %q, want %q", calls[0].Name, "session_search")
+		}
+		var args map[string]any
+		if err := json.Unmarshal([]byte(calls[0].Arguments), &args); err != nil {
+			t.Fatalf("invalid arguments JSON: %v", err)
+		}
+		if args["query"] != "quest team OR hermes deploy" {
+			t.Errorf("query: got %v", args["query"])
+		}
+	})
+
+	t.Run("think block then tool call", func(t *testing.T) {
+		input := "<|channel>thought\nLet me think.\n<channel|>\n<|tool_call>call:lookup{id:<|\"|>42<|\"|>}<tool_call|>"
+		cleaned, calls := gemma4ParseContent(input)
+		if cleaned != "" {
+			t.Errorf("expected empty content after tool call removal, got %q", cleaned)
+		}
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 tool call, got %d", len(calls))
+		}
+		if calls[0].Name != "lookup" {
+			t.Errorf("name: got %q", calls[0].Name)
+		}
+	})
+
+	t.Run("text with no special tokens", func(t *testing.T) {
+		input := "Hello, world!"
+		cleaned, calls := gemma4ParseContent(input)
+		if cleaned != input {
+			t.Errorf("got %q, want %q", cleaned, input)
+		}
+		if len(calls) != 0 {
+			t.Errorf("expected no calls, got %d", len(calls))
+		}
+	})
+}
+
+func TestRewriteGemma4Choices(t *testing.T) {
+	t.Run("tool call extracted", func(t *testing.T) {
+		input := `[{"index":0,"message":{"role":"assistant","content":"<|tool_call>call:my_tool{arg:<|\"|\">hello<|\"|\">}<tool_call|>"},"finish_reason":"stop"}]`
+		out := rewriteGemma4Choices(json.RawMessage(input))
+
+		var arr []struct {
+			Message struct {
+				Content   *string `json:"content"`
+				ToolCalls []struct {
+					Type     string `json:"type"`
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		}
+		if err := json.Unmarshal(out, &arr); err != nil {
+			t.Fatalf("invalid output JSON: %v", err)
+		}
+		if len(arr) == 0 {
+			t.Fatal("empty choices")
+		}
+		c := arr[0]
+		if c.Message.Content != nil {
+			t.Errorf("expected null content, got %q", *c.Message.Content)
+		}
+		if len(c.Message.ToolCalls) != 1 {
+			t.Fatalf("expected 1 tool call, got %d", len(c.Message.ToolCalls))
+		}
+		if c.Message.ToolCalls[0].Function.Name != "my_tool" {
+			t.Errorf("name: got %q", c.Message.ToolCalls[0].Function.Name)
+		}
+		if c.FinishReason != "tool_calls" {
+			t.Errorf("finish_reason: got %q, want tool_calls", c.FinishReason)
+		}
+	})
+
+	t.Run("think block stripped", func(t *testing.T) {
+		input := `[{"index":0,"message":{"role":"assistant","content":"<|channel>thought\ninternal\n<channel|>\nActual answer."},"finish_reason":"stop"}]`
+		out := rewriteGemma4Choices(json.RawMessage(input))
+
+		var arr []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(out, &arr); err != nil {
+			t.Fatalf("invalid output JSON: %v", err)
+		}
+		if arr[0].Message.Content != "Actual answer." {
+			t.Errorf("got %q, want %q", arr[0].Message.Content, "Actual answer.")
+		}
+	})
+
+	t.Run("no gemma4 tokens passthrough", func(t *testing.T) {
+		input := `[{"index":0,"message":{"role":"assistant","content":"plain text"},"finish_reason":"stop"}]`
+		out := rewriteGemma4Choices(json.RawMessage(input))
+		// Should return the same bytes when nothing changes.
+		if string(out) != input {
+			// May differ in whitespace from re-marshal; just check it parses the same.
+			var a, b []map[string]any
+			json.Unmarshal(json.RawMessage(input), &a)
+			json.Unmarshal(out, &b)
+			if len(a) != len(b) {
+				t.Errorf("passthrough altered choices: %s", out)
+			}
+		}
+	})
+}

--- a/internal/httpapi/handlers_admin.go
+++ b/internal/httpapi/handlers_admin.go
@@ -566,6 +566,7 @@ func ModelsUpsertHandler(d Dependencies) http.HandlerFunc {
 				OutputPer1K:      m.OutputPer1K,
 				Enabled:          m.Enabled,
 				PricingSource:    m.PricingSource,
+				ToolNameMap:      m.ToolNameMap,
 			}
 			if rec.PricingSource == "" {
 				rec.PricingSource = "manual"
@@ -676,7 +677,7 @@ func ModelsPatchHandler(d Dependencies) http.HandlerFunc {
 						ID: m.ID, ProviderID: m.ProviderID, Weight: m.Weight,
 						MaxContextTokens: m.MaxContextTokens, InputPer1K: m.InputPer1K,
 						OutputPer1K: m.OutputPer1K, Enabled: m.Enabled,
-						PricingSource: m.PricingSource,
+						PricingSource: m.PricingSource, ToolNameMap: m.ToolNameMap,
 					}
 					break
 				}
@@ -747,6 +748,18 @@ func ModelsPatchHandler(d Dependencies) http.HandlerFunc {
 		if pricingPatched {
 			existing.PricingSource = "manual"
 		}
+		if v, ok := patch["tool_name_map"]; ok {
+			if m, ok := v.(map[string]any); ok {
+				existing.ToolNameMap = make(map[string]string, len(m))
+				for k, val := range m {
+					if s, ok := val.(string); ok {
+						existing.ToolNameMap[k] = s
+					}
+				}
+			} else if v == nil {
+				existing.ToolNameMap = nil
+			}
+		}
 
 		// Update store and engine.
 		if err := d.Store.UpsertModel(r.Context(), *existing); err != nil {
@@ -762,6 +775,7 @@ func ModelsPatchHandler(d Dependencies) http.HandlerFunc {
 			OutputPer1K:      existing.OutputPer1K,
 			Enabled:          existing.Enabled,
 			PricingSource:    existing.PricingSource,
+			ToolNameMap:      existing.ToolNameMap,
 		})
 		if d.Store != nil {
 			d.warnOnErr("audit", d.Store.LogAudit(r.Context(), store.AuditEntry{

--- a/internal/httpapi/handlers_admin.go
+++ b/internal/httpapi/handlers_admin.go
@@ -567,6 +567,7 @@ func ModelsUpsertHandler(d Dependencies) http.HandlerFunc {
 				Enabled:          m.Enabled,
 				PricingSource:    m.PricingSource,
 				ToolNameMap:      m.ToolNameMap,
+				Gemma4Output:     m.Gemma4Output,
 			}
 			if rec.PricingSource == "" {
 				rec.PricingSource = "manual"
@@ -678,6 +679,7 @@ func ModelsPatchHandler(d Dependencies) http.HandlerFunc {
 						MaxContextTokens: m.MaxContextTokens, InputPer1K: m.InputPer1K,
 						OutputPer1K: m.OutputPer1K, Enabled: m.Enabled,
 						PricingSource: m.PricingSource, ToolNameMap: m.ToolNameMap,
+						Gemma4Output: m.Gemma4Output,
 					}
 					break
 				}
@@ -760,6 +762,11 @@ func ModelsPatchHandler(d Dependencies) http.HandlerFunc {
 				existing.ToolNameMap = nil
 			}
 		}
+		if v, ok := patch["gemma4_output"]; ok {
+			if b, ok := v.(bool); ok {
+				existing.Gemma4Output = b
+			}
+		}
 
 		// Update store and engine.
 		if err := d.Store.UpsertModel(r.Context(), *existing); err != nil {
@@ -776,6 +783,7 @@ func ModelsPatchHandler(d Dependencies) http.HandlerFunc {
 			Enabled:          existing.Enabled,
 			PricingSource:    existing.PricingSource,
 			ToolNameMap:      existing.ToolNameMap,
+			Gemma4Output:     existing.Gemma4Output,
 		})
 		if d.Store != nil {
 			d.warnOnErr("audit", d.Store.LogAudit(r.Context(), store.AuditEntry{

--- a/internal/httpapi/handlers_openai.go
+++ b/internal/httpapi/handlers_openai.go
@@ -185,9 +185,14 @@ func ChatCompletionsHandler(d Dependencies) http.HandlerFunc {
 				writeOpenAIError(w, serr.Error(), "server_error", http.StatusBadGateway)
 				return
 			}
-			// Use the actual routed model's tool name map for inbound rewriting.
-			if m, ok := d.Engine.GetModel(decision.ModelID); ok && len(m.ToolNameMap) > 0 {
-				body = newSSEToolNameRewriter(body, m.ToolNameMap)
+			// Apply model-specific output transformations.
+			if m, ok := d.Engine.GetModel(decision.ModelID); ok {
+				if m.Gemma4Output {
+					body = newSSEGemma4Transformer(body)
+				}
+				if len(m.ToolNameMap) > 0 {
+					body = newSSEToolNameRewriter(body, m.ToolNameMap)
+				}
 			}
 			defer func() { _ = body.Close() }()
 
@@ -304,9 +309,14 @@ func ChatCompletionsHandler(d Dependencies) http.HandlerFunc {
 		// Build OpenAI-compatible response.
 		oaiResp := buildCompletionsResponse(reqID, decision.ModelID, resp)
 
-		// Rewrite tool call names in the response (model-facing → client-facing).
-		if inMap, ok := d.Engine.GetModel(decision.ModelID); ok && len(inMap.ToolNameMap) > 0 {
-			oaiResp.Choices = rewriteChoicesToolCalls(oaiResp.Choices, inMap.ToolNameMap)
+		// Apply model-specific output transformations.
+		if m, ok := d.Engine.GetModel(decision.ModelID); ok {
+			if m.Gemma4Output {
+				oaiResp.Choices = rewriteGemma4Choices(oaiResp.Choices)
+			}
+			if len(m.ToolNameMap) > 0 {
+				oaiResp.Choices = rewriteChoicesToolCalls(oaiResp.Choices, m.ToolNameMap)
+			}
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/httpapi/handlers_openai.go
+++ b/internal/httpapi/handlers_openai.go
@@ -22,11 +22,13 @@ type CompletionsRequest struct {
 	Stream   bool             `json:"stream,omitempty"`
 
 	// Optional parameters forwarded to the provider.
-	Temperature *float64 `json:"temperature,omitempty"`
-	MaxTokens   *int     `json:"max_tokens,omitempty"`
-	TopP        *float64 `json:"top_p,omitempty"`
-	Stop        any      `json:"stop,omitempty"`
-	N           *int     `json:"n,omitempty"`
+	Temperature *float64        `json:"temperature,omitempty"`
+	MaxTokens   *int            `json:"max_tokens,omitempty"`
+	TopP        *float64        `json:"top_p,omitempty"`
+	Stop        any             `json:"stop,omitempty"`
+	N           *int            `json:"n,omitempty"`
+	Tools       json.RawMessage `json:"tools,omitempty"`
+	ToolChoice  json.RawMessage `json:"tool_choice,omitempty"`
 }
 
 // completionsResponse is the OpenAI-compatible response for /v1/chat/completions.
@@ -125,6 +127,29 @@ func ChatCompletionsHandler(d Dependencies) http.HandlerFunc {
 			}
 		}
 
+		// Look up tool name map for the hinted model. Used to rewrite tool names
+		// in both directions: outbound (client→model) uses the reversed map,
+		// inbound (model→client) uses the map directly.
+		var toolNameMap map[string]string
+		if m, ok := d.Engine.GetModel(modelHint); ok {
+			toolNameMap = m.ToolNameMap
+		}
+
+		// Forward tool definitions, rewriting names from client-facing to model-facing.
+		if len(req.Tools) > 0 {
+			tools := rewriteToolNames(req.Tools, reverseMap(toolNameMap))
+			var toolsVal any
+			if err := json.Unmarshal(tools, &toolsVal); err == nil {
+				params["tools"] = toolsVal
+			}
+		}
+		if len(req.ToolChoice) > 0 {
+			var tcVal any
+			if err := json.Unmarshal(req.ToolChoice, &tcVal); err == nil {
+				params["tool_choice"] = tcVal
+			}
+		}
+
 		// Translate to router.Request.
 		routerReq := router.Request{
 			Messages:  req.Messages,
@@ -159,6 +184,10 @@ func ChatCompletionsHandler(d Dependencies) http.HandlerFunc {
 			if serr != nil {
 				writeOpenAIError(w, serr.Error(), "server_error", http.StatusBadGateway)
 				return
+			}
+			// Use the actual routed model's tool name map for inbound rewriting.
+			if m, ok := d.Engine.GetModel(decision.ModelID); ok && len(m.ToolNameMap) > 0 {
+				body = newSSEToolNameRewriter(body, m.ToolNameMap)
 			}
 			defer func() { _ = body.Close() }()
 
@@ -274,6 +303,11 @@ func ChatCompletionsHandler(d Dependencies) http.HandlerFunc {
 
 		// Build OpenAI-compatible response.
 		oaiResp := buildCompletionsResponse(reqID, decision.ModelID, resp)
+
+		// Rewrite tool call names in the response (model-facing → client-facing).
+		if inMap, ok := d.Engine.GetModel(decision.ModelID); ok && len(inMap.ToolNameMap) > 0 {
+			oaiResp.Choices = rewriteChoicesToolCalls(oaiResp.Choices, inMap.ToolNameMap)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(oaiResp)

--- a/internal/httpapi/tool_rewrite.go
+++ b/internal/httpapi/tool_rewrite.go
@@ -1,0 +1,193 @@
+package httpapi
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// reverseMap returns a new map with keys and values swapped.
+func reverseMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	rev := make(map[string]string, len(m))
+	for k, v := range m {
+		rev[v] = k
+	}
+	return rev
+}
+
+// rewriteToolNames rewrites function names in an OpenAI-format tools array.
+// tools is a JSON array of tool objects; nameMap maps old names to new names.
+// Returns the original slice unchanged if nameMap is empty or parsing fails.
+func rewriteToolNames(tools json.RawMessage, nameMap map[string]string) json.RawMessage {
+	if len(nameMap) == 0 || len(tools) == 0 {
+		return tools
+	}
+	var arr []struct {
+		Type     string `json:"type"`
+		Function struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description,omitempty"`
+			Parameters  json.RawMessage `json:"parameters,omitempty"`
+			Strict      *bool           `json:"strict,omitempty"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(tools, &arr); err != nil {
+		return tools
+	}
+	changed := false
+	for i, t := range arr {
+		if newName, ok := nameMap[t.Function.Name]; ok {
+			arr[i].Function.Name = newName
+			changed = true
+		}
+	}
+	if !changed {
+		return tools
+	}
+	out, err := json.Marshal(arr)
+	if err != nil {
+		return tools
+	}
+	return out
+}
+
+// rewriteChoicesToolCalls rewrites tool call function names in an OpenAI choices
+// array (non-streaming). nameMap maps old names to new names.
+func rewriteChoicesToolCalls(choices json.RawMessage, nameMap map[string]string) json.RawMessage {
+	if len(nameMap) == 0 || len(choices) == 0 {
+		return choices
+	}
+	type toolFunction struct {
+		Name      string `json:"name,omitempty"`
+		Arguments string `json:"arguments,omitempty"`
+	}
+	type toolCall struct {
+		ID       string       `json:"id,omitempty"`
+		Type     string       `json:"type,omitempty"`
+		Function toolFunction `json:"function"`
+	}
+	type message struct {
+		Role      string          `json:"role,omitempty"`
+		Content   json.RawMessage `json:"content,omitempty"`
+		ToolCalls []toolCall      `json:"tool_calls,omitempty"`
+	}
+	type choice struct {
+		Index        int             `json:"index"`
+		Message      message         `json:"message"`
+		FinishReason *string         `json:"finish_reason"`
+		Logprobs     json.RawMessage `json:"logprobs,omitempty"`
+	}
+
+	var arr []choice
+	if err := json.Unmarshal(choices, &arr); err != nil {
+		return choices
+	}
+	changed := false
+	for i, c := range arr {
+		for j, tc := range c.Message.ToolCalls {
+			if newName, ok := nameMap[tc.Function.Name]; ok {
+				arr[i].Message.ToolCalls[j].Function.Name = newName
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return choices
+	}
+	out, err := json.Marshal(arr)
+	if err != nil {
+		return choices
+	}
+	return out
+}
+
+// newSSEToolNameRewriter wraps an SSE stream and rewrites tool call function
+// names in streaming chunks on the fly. nameMap maps old names to new names.
+// If nameMap is empty, src is returned unchanged.
+func newSSEToolNameRewriter(src io.ReadCloser, nameMap map[string]string) io.ReadCloser {
+	if len(nameMap) == 0 {
+		return src
+	}
+	pr, pw := io.Pipe()
+	go func() {
+		defer src.Close()
+		defer pw.Close()
+		scanner := bufio.NewScanner(src)
+		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "data: ") {
+				data := line[6:]
+				if data != "[DONE]" {
+					line = "data: " + rewriteSSEChunkToolNames(data, nameMap)
+				}
+			}
+			if _, err := pw.Write([]byte(line + "\n")); err != nil {
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			pw.CloseWithError(err)
+		}
+	}()
+	return pr
+}
+
+// rewriteSSEChunkToolNames rewrites tool call names in a single SSE data payload.
+func rewriteSSEChunkToolNames(data string, nameMap map[string]string) string {
+	type toolFunction struct {
+		Name      string `json:"name,omitempty"`
+		Arguments string `json:"arguments,omitempty"`
+	}
+	type toolCallDelta struct {
+		Index    int          `json:"index"`
+		ID       string       `json:"id,omitempty"`
+		Type     string       `json:"type,omitempty"`
+		Function toolFunction `json:"function,omitempty"`
+	}
+	type delta struct {
+		Role      string          `json:"role,omitempty"`
+		Content   json.RawMessage `json:"content,omitempty"`
+		ToolCalls []toolCallDelta `json:"tool_calls,omitempty"`
+	}
+	type choice struct {
+		Index        int             `json:"index"`
+		Delta        delta           `json:"delta"`
+		FinishReason *string         `json:"finish_reason"`
+		Logprobs     json.RawMessage `json:"logprobs,omitempty"`
+	}
+	type chunk struct {
+		ID      string          `json:"id,omitempty"`
+		Object  string          `json:"object,omitempty"`
+		Created int64           `json:"created,omitempty"`
+		Model   string          `json:"model,omitempty"`
+		Choices []choice        `json:"choices"`
+		Usage   json.RawMessage `json:"usage,omitempty"`
+	}
+
+	var c chunk
+	if err := json.Unmarshal([]byte(data), &c); err != nil {
+		return data
+	}
+	changed := false
+	for i, ch := range c.Choices {
+		for j, tc := range ch.Delta.ToolCalls {
+			if newName, ok := nameMap[tc.Function.Name]; ok {
+				c.Choices[i].Delta.ToolCalls[j].Function.Name = newName
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return data
+	}
+	out, err := json.Marshal(c)
+	if err != nil {
+		return data
+	}
+	return string(out)
+}

--- a/internal/router/types.go
+++ b/internal/router/types.go
@@ -126,6 +126,10 @@ type Model struct {
 	OutputPer1K      float64 `json:"output_per_1k"`
 	Enabled          bool    `json:"enabled"`
 	PricingSource    string  `json:"pricing_source,omitempty"`
+	// ToolNameMap maps model-facing tool names to client-facing tool names.
+	// Applied to tool_calls in responses (model→client) and inverted for
+	// tool definitions in requests (client→model).
+	ToolNameMap map[string]string `json:"tool_name_map,omitempty"`
 }
 
 // OrchestrationDirective configures multi-model orchestration (adversarial, vote, refine).

--- a/internal/router/types.go
+++ b/internal/router/types.go
@@ -130,6 +130,11 @@ type Model struct {
 	// Applied to tool_calls in responses (model→client) and inverted for
 	// tool definitions in requests (client→model).
 	ToolNameMap map[string]string `json:"tool_name_map,omitempty"`
+	// Gemma4Output enables parsing of Gemma 4's non-standard response tokens:
+	// <|channel>thought\n...<channel|> thinking blocks are stripped, and
+	// <|tool_call>call:name{...}<tool_call|> inline tool calls are converted
+	// to the standard OpenAI tool_calls format.
+	Gemma4Output bool `json:"gemma4_output,omitempty"`
 }
 
 // OrchestrationDirective configures multi-model orchestration (adversarial, vote, refine).

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -241,6 +241,9 @@ var schemaMigrations = []migration{
 	sqlMigration(8, "add_api_keys_budget_reset_at",
 		`ALTER TABLE api_keys ADD COLUMN budget_reset_at TEXT`,
 	),
+	sqlMigration(9, "add_models_tool_name_map",
+		`ALTER TABLE models ADD COLUMN tool_name_map TEXT NOT NULL DEFAULT '{}'`,
+	),
 }
 
 // Migrate applies all pending schema migrations in version order.
@@ -300,9 +303,22 @@ func (s *SQLiteStore) Close() error {
 
 // Models
 
+func scanModelRecord(scan func(...any) error) (ModelRecord, error) {
+	var m ModelRecord
+	var toolNameMapJSON string
+	if err := scan(&m.ID, &m.ProviderID, &m.Weight, &m.MaxContextTokens,
+		&m.InputPer1K, &m.OutputPer1K, &m.Enabled, &m.PricingSource, &toolNameMapJSON); err != nil {
+		return m, err
+	}
+	if toolNameMapJSON != "" && toolNameMapJSON != "{}" {
+		_ = json.Unmarshal([]byte(toolNameMapJSON), &m.ToolNameMap)
+	}
+	return m, nil
+}
+
 func (s *SQLiteStore) ListModels(ctx context.Context) ([]ModelRecord, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source FROM models`)
+		`SELECT id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source, tool_name_map FROM models`)
 	if err != nil {
 		return nil, err
 	}
@@ -310,8 +326,8 @@ func (s *SQLiteStore) ListModels(ctx context.Context) ([]ModelRecord, error) {
 
 	var models []ModelRecord
 	for rows.Next() {
-		var m ModelRecord
-		if err := rows.Scan(&m.ID, &m.ProviderID, &m.Weight, &m.MaxContextTokens, &m.InputPer1K, &m.OutputPer1K, &m.Enabled, &m.PricingSource); err != nil {
+		m, err := scanModelRecord(rows.Scan)
+		if err != nil {
 			return nil, err
 		}
 		models = append(models, m)
@@ -320,10 +336,9 @@ func (s *SQLiteStore) ListModels(ctx context.Context) ([]ModelRecord, error) {
 }
 
 func (s *SQLiteStore) GetModel(ctx context.Context, id string) (*ModelRecord, error) {
-	var m ModelRecord
-	err := s.db.QueryRowContext(ctx,
-		`SELECT id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source FROM models WHERE id = ?`, id).
-		Scan(&m.ID, &m.ProviderID, &m.Weight, &m.MaxContextTokens, &m.InputPer1K, &m.OutputPer1K, &m.Enabled, &m.PricingSource)
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source, tool_name_map FROM models WHERE id = ?`, id)
+	m, err := scanModelRecord(row.Scan)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -337,9 +352,14 @@ func (s *SQLiteStore) UpsertModel(ctx context.Context, m ModelRecord) error {
 	if m.PricingSource == "" {
 		m.PricingSource = "manual"
 	}
+	toolNameMapJSON := "{}"
+	if len(m.ToolNameMap) > 0 {
+		b, _ := json.Marshal(m.ToolNameMap)
+		toolNameMapJSON = string(b)
+	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO models (id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO models (id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source, tool_name_map)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
 		   provider_id=excluded.provider_id,
 		   weight=excluded.weight,
@@ -347,8 +367,9 @@ func (s *SQLiteStore) UpsertModel(ctx context.Context, m ModelRecord) error {
 		   input_per_1k=excluded.input_per_1k,
 		   output_per_1k=excluded.output_per_1k,
 		   enabled=excluded.enabled,
-		   pricing_source=excluded.pricing_source`,
-		m.ID, m.ProviderID, m.Weight, m.MaxContextTokens, m.InputPer1K, m.OutputPer1K, m.Enabled, m.PricingSource)
+		   pricing_source=excluded.pricing_source,
+		   tool_name_map=excluded.tool_name_map`,
+		m.ID, m.ProviderID, m.Weight, m.MaxContextTokens, m.InputPer1K, m.OutputPer1K, m.Enabled, m.PricingSource, toolNameMapJSON)
 	return err
 }
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -244,6 +244,9 @@ var schemaMigrations = []migration{
 	sqlMigration(9, "add_models_tool_name_map",
 		`ALTER TABLE models ADD COLUMN tool_name_map TEXT NOT NULL DEFAULT '{}'`,
 	),
+	sqlMigration(10, "add_models_gemma4_output",
+		`ALTER TABLE models ADD COLUMN gemma4_output BOOLEAN NOT NULL DEFAULT 0`,
+	),
 }
 
 // Migrate applies all pending schema migrations in version order.
@@ -307,7 +310,7 @@ func scanModelRecord(scan func(...any) error) (ModelRecord, error) {
 	var m ModelRecord
 	var toolNameMapJSON string
 	if err := scan(&m.ID, &m.ProviderID, &m.Weight, &m.MaxContextTokens,
-		&m.InputPer1K, &m.OutputPer1K, &m.Enabled, &m.PricingSource, &toolNameMapJSON); err != nil {
+		&m.InputPer1K, &m.OutputPer1K, &m.Enabled, &m.PricingSource, &toolNameMapJSON, &m.Gemma4Output); err != nil {
 		return m, err
 	}
 	if toolNameMapJSON != "" && toolNameMapJSON != "{}" {
@@ -318,7 +321,7 @@ func scanModelRecord(scan func(...any) error) (ModelRecord, error) {
 
 func (s *SQLiteStore) ListModels(ctx context.Context) ([]ModelRecord, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source, tool_name_map FROM models`)
+		`SELECT id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source, tool_name_map, gemma4_output FROM models`)
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +340,7 @@ func (s *SQLiteStore) ListModels(ctx context.Context) ([]ModelRecord, error) {
 
 func (s *SQLiteStore) GetModel(ctx context.Context, id string) (*ModelRecord, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source, tool_name_map FROM models WHERE id = ?`, id)
+		`SELECT id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source, tool_name_map, gemma4_output FROM models WHERE id = ?`, id)
 	m, err := scanModelRecord(row.Scan)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -358,8 +361,8 @@ func (s *SQLiteStore) UpsertModel(ctx context.Context, m ModelRecord) error {
 		toolNameMapJSON = string(b)
 	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO models (id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source, tool_name_map)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO models (id, provider_id, weight, max_context_tokens, input_per_1k, output_per_1k, enabled, pricing_source, tool_name_map, gemma4_output)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
 		   provider_id=excluded.provider_id,
 		   weight=excluded.weight,
@@ -368,8 +371,9 @@ func (s *SQLiteStore) UpsertModel(ctx context.Context, m ModelRecord) error {
 		   output_per_1k=excluded.output_per_1k,
 		   enabled=excluded.enabled,
 		   pricing_source=excluded.pricing_source,
-		   tool_name_map=excluded.tool_name_map`,
-		m.ID, m.ProviderID, m.Weight, m.MaxContextTokens, m.InputPer1K, m.OutputPer1K, m.Enabled, m.PricingSource, toolNameMapJSON)
+		   tool_name_map=excluded.tool_name_map,
+		   gemma4_output=excluded.gemma4_output`,
+		m.ID, m.ProviderID, m.Weight, m.MaxContextTokens, m.InputPer1K, m.OutputPer1K, m.Enabled, m.PricingSource, toolNameMapJSON, m.Gemma4Output)
 	return err
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -76,14 +76,15 @@ type Store interface {
 
 // ModelRecord is the persisted form of a model configuration.
 type ModelRecord struct {
-	ID               string  `json:"id"`
-	ProviderID       string  `json:"provider_id"`
-	Weight           int     `json:"weight"`
-	MaxContextTokens int     `json:"max_context_tokens"`
-	InputPer1K       float64 `json:"input_per_1k"`
-	OutputPer1K      float64 `json:"output_per_1k"`
-	Enabled          bool    `json:"enabled"`
-	PricingSource    string  `json:"pricing_source"` // "manual" | "litellm" | "provider"
+	ID               string            `json:"id"`
+	ProviderID       string            `json:"provider_id"`
+	Weight           int               `json:"weight"`
+	MaxContextTokens int               `json:"max_context_tokens"`
+	InputPer1K       float64           `json:"input_per_1k"`
+	OutputPer1K      float64           `json:"output_per_1k"`
+	Enabled          bool              `json:"enabled"`
+	PricingSource    string            `json:"pricing_source"` // "manual" | "litellm" | "provider"
+	ToolNameMap      map[string]string `json:"tool_name_map,omitempty"`
 }
 
 // ProviderRecord is the persisted form of a provider configuration.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -85,6 +85,7 @@ type ModelRecord struct {
 	Enabled          bool              `json:"enabled"`
 	PricingSource    string            `json:"pricing_source"` // "manual" | "litellm" | "provider"
 	ToolNameMap      map[string]string `json:"tool_name_map,omitempty"`
+	Gemma4Output     bool              `json:"gemma4_output,omitempty"`
 }
 
 // ProviderRecord is the persisted form of a provider configuration.


### PR DESCRIPTION
## Summary

- **Tool name rewriting**: adds a per-model `tool_name_map` that translates tool names between client-facing and model-facing identifiers in both directions — outbound tool definitions (client→model) use the reversed map, inbound `tool_calls` responses (model→client) use the map directly. Works for both streaming and non-streaming paths.
- **Gemma 4 output parsing**: Gemma 4 (served via vLLM) emits non-standard tokens that confuse OpenAI-compatible clients. This PR adds a `gemma4_output` flag on models that enables two transforms:
  - Strip `<|channel>thought\n...<channel|>` thinking blocks from content
  - Convert `<|tool_call>call:name{key:<|"|>val<|"|>,...}<tool_call|>` inline tokens into standard OpenAI `tool_calls` entries
  - SSE streaming is handled by buffering all content deltas per choice and re-emitting structured chunks once the stream ends (necessary because tool call tokens span many deltas)
- **DB migration 10**: adds `gemma4_output` boolean column to the `models` table; flag is hot-patchable via `PATCH /admin/v1/models/*` and persists across restarts

## Test plan

- [ ] `go test ./internal/httpapi/` — unit tests for `gemma4ArgsToJSON`, `gemma4ParseContent`, `rewriteGemma4Choices`
- [ ] PATCH a Gemma 4 model with `{"gemma4_output": true}`, verify the flag persists after server restart
- [ ] Send a non-streaming chat completion through a Gemma 4 model that returns a tool call token; verify the response contains a proper `tool_calls` entry and null `content`
- [ ] Send a streaming request; verify SSE chunks contain role delta, optional content delta, tool call deltas with `index`/`id`/`type`/`function`, and a final `finish_reason: tool_calls` chunk
- [ ] Verify thinking block content is stripped from both streaming and non-streaming responses
- [ ] Verify models without `gemma4_output` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)